### PR TITLE
Removing words starting with 0

### DIFF
--- a/src/pylangacq/_clean_utterance.py
+++ b/src/pylangacq/_clean_utterance.py
@@ -16,6 +16,7 @@ _REGEX_DROP = (
     re.compile(r"\[>\d?\]"),
     re.compile(r"\((\d+?:)?\d+?\.?\d*?\)"),
     re.compile(r"\[%act: [^\[]+?\]"),
+    re.compile(r"\b0\w+"),
 )
 
 _REGEX_REPLACE = (
@@ -164,6 +165,7 @@ def _clean_utterance(utterance: str) -> str:
     #     (.) (short pause)
     # then pad them with extra spaces.
 
+    print('mila.')
     for regex in _REGEX_DROP:
         utterance = regex.sub("", utterance)
 
@@ -284,3 +286,6 @@ def _clean_utterance(utterance: str) -> str:
             new_words.append(word)
 
     return " ".join(new_words).strip()
+
+
+print(_clean_utterance("I 0am done."))

--- a/tests/test__clean_utterance.py
+++ b/tests/test__clean_utterance.py
@@ -59,6 +59,7 @@ from pylangacq._clean_utterance import _clean_utterance
         ("⌈ foo bar ⌉", "foo bar"),  # overlapping markers
         ("foo.", "foo ."),
         ("+...", "+..."),
+        # ("I 0am done.", "I done ."),  # CHILDES -> Biling -> Perez -> Shelia
     ],
 )
 def test__clean_utterance(original, expected):


### PR DESCRIPTION
Removing Omitted Words, annotated as 0word, because they were added by the annotator and are not part of the authentic child produced speech. 
- [done] Add a concise title to this pull request on the GitHub web interface.
- [done ] Add a description in this box to describe what this pull request is about.

- [ ] If code behavior is being updated (e.g., a bug fix), relevant tests should be added.
- [ ] The CircleCI builds should pass, including both the code styling checks by
      `black` and `flake8` as well as the test suite.
- [ ] Add an entry to `CHANGELOG.md` at the repository's root level.
